### PR TITLE
Test if `dynarray` instance is empty iff its underlying pointer is empty

### DIFF
--- a/dynarray.hpp
+++ b/dynarray.hpp
@@ -450,7 +450,7 @@ auto utils::dynarray<T>::data() const -> const_pointer {
 
 template<typename T>
 auto utils::dynarray<T>::empty() const -> bool {
-	return m_size == 0;
+	return !m_data.get();
 }
 
 template<typename T>


### PR DESCRIPTION
The incentive for this is change is the following scenario - after `src` was **moved** into `dst`, `src` is actually an empty instance

```
TEST(FaceFeatureVecTests, MoveSemantics)
{
    dynarray<float> src(128);    
    src.fill(42.0f);
    ASSERT_FALSE(src.empty());

    const auto dst = move(src);
    ASSERT_TRUE(src.empty());
}
```