### PR TITLE
Using std::string_literals requires <string>

### DIFF
--- a/dynarray.hpp
+++ b/dynarray.hpp
@@ -32,6 +32,7 @@
 // headers used by definition site
 #include <algorithm>
 #include <stdexcept>
+#include <string>
 
 //============================================================
 // DECLARATION


### PR DESCRIPTION
See https://en.cppreference.com/w/cpp/string/basic_string/operator%22%22s