### PR TITLE
<string> library is needed to use std::to_string()

### DIFF
--- a/dynarray.hpp
+++ b/dynarray.hpp
@@ -32,6 +32,7 @@
 // headers used by definition site
 #include <algorithm>
 #include <stdexcept>
+#include <string>
 
 //============================================================
 // DECLARATION


### PR DESCRIPTION
If `<string>` is not included, the compiler throws the following error: `error C2039: 'to_string': is not a member of 'std'.`